### PR TITLE
add support for 32bit/m depth encoding

### DIFF
--- a/src/hri_fullbody/fullbody_detector.py
+++ b/src/hri_fullbody/fullbody_detector.py
@@ -743,6 +743,7 @@ class FullbodyDetector:
                 torso_px[1],
                 self.rgb_info,
                 self.depth_info,
+                self.depth_encoding,
                 self.image_depth,
                 self.roi.xmin,
                 self.roi.ymin
@@ -1171,6 +1172,8 @@ class FullbodyDetector:
         rgb_img = self.br.imgmsg_to_cv2(rgb_img)
         image_depth = self.br.imgmsg_to_cv2(depth_img, "16UC1")
         self.image_depth = image_depth
+        if not hasattr(self, 'depth_encoding'):
+            self.depth_encoding = depth_img.encoding
         if depth_info.header.stamp > rgb_info.header.stamp:
             header = copy.copy(depth_info.header)
             header.frame_id = rgb_info.header.frame_id # to check 
@@ -1194,6 +1197,8 @@ class FullbodyDetector:
         rgb_img = self.br.imgmsg_to_cv2(rgb_img)
         image_depth = self.br.imgmsg_to_cv2(depth_img, "16UC1")
         self.image_depth = image_depth
+        if not hasattr(self, 'depth_encoding'):
+            self.depth_encoding = depth_img.encoding
         if depth_info.header.stamp > rgb_info.header.stamp:
             header = copy.copy(depth_info.header)
             header.frame_id = rgb_info.header.frame_id # to check 

--- a/src/hri_fullbody/rs_to_depth.py
+++ b/src/hri_fullbody/rs_to_depth.py
@@ -7,6 +7,7 @@ def rgb_to_xyz(
         y_rgb,
         rgb_camera_info,
         depth_camera_info,
+        depth_data_encoding,
         depth_data,
         roi_xmin = 0.,
         roi_ymin = 0.):
@@ -32,7 +33,17 @@ def rgb_to_xyz(
                * depth_model.fy()
                / rgb_model.fy())
               + depth_model.cy())
-    z = depth_data[y_d][x_d]/1000
+    
+    if depth_data_encoding == '32FC1':
+        # Get depth data encoded as 32bit/m
+        z = depth_data[y_d][x_d]
+    elif depth_data_encoding == '16UC1':
+        # Convert depth data encoded as 16bit/mm to m
+        z = depth_data[y_d][x_d]/1000
+    else:
+        raise ValueError('Unexpected encoding {}. '.format(depth_data_encoding) +\
+                         'Depth encoding should be 16UC1 or `32FC1`.')
+    
     x = (x_d - depth_model.cx())*z/depth_model.fx()
     y = (y_d - depth_model.cy())*z/depth_model.fy()
 


### PR DESCRIPTION
This PR implements the changes described in #5 to add support for depth data encoded as 32bit floats.

The code checks for the encoding on the depth topic (if `use_depth` is true) by **waiting** 10s for a depth message. If the 10s timeout is reached, the encoding defaults to the original `16UC1`.
I am not a huge fan of `rospy.wait_for_message` but I find more reasonable to add a little overhead than re-reading the (same) encoding from each and every Image msg.